### PR TITLE
Install new Node.js version via nvm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,14 +158,14 @@ def done():
 
 def execute_all():
     print_header()
-    # check_super_user()
+    check_super_user()
 
     install_node()
-    # setup_access_point()
+    setup_access_point()
 
-    # install_server_dependencies()
-    # build_server()
-    # setup_server_service()
+    install_server_dependencies()
+    build_server()
+    setup_server_service()
 
     done()
 

--- a/setup.py
+++ b/setup.py
@@ -33,15 +33,19 @@ def check_super_user():
 
 
 def install_node():
+    NODE_JS_VERSION = 22  # EOL: October 2025 (https://nodejs.org/en/about/previous-releases)
+
+    def get_versions():
+        res = subprocess.run(["npm", "version", "--json"], capture_output=True, check=True)
+        return json.loads(res.stdout)
+
     print()
     ColorPrint.print(cyan, "▶ Node.js & npm")
 
     # Already installed?
-    installed = False
     data = {}
     try:
-        res = subprocess.run(["npm", "version", "--json"], capture_output=True, check=True)
-        data = json.loads(res.stdout)
+        data = get_versions()
         if data["npm"] and data["node"]:
             installed = True
     except Exception:  # pylint: disable=broad-except
@@ -51,26 +55,27 @@ def install_node():
         print(f'You have Node.js v{data["node"]} and npm v{data["npm"]} installed.')
 
         majorVersion = data["node"].split(".")[0]
-        if int(majorVersion) < 16:
+        if int(majorVersion) < NODE_JS_VERSION:
             answer = query_yes_no(
-                "Would you still like to try installing Node.js v18.x (LTS)?",
+                f"Would you still like to try installing Node.js v{NODE_JS_VERSION}.x (LTS)?",
                 default="yes",
             )
             installed = not answer
 
     # Install
     if not installed:
-        # https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
+        # https://nodejs.org/en/download
         subprocess.run(
-            "curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -",
+            "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash",
             shell=True,
             check=True,
         )
-        subprocess.run("sudo apt-get install -y nodejs", shell=True, check=True)
-
-        # npm might not be installed alongside Node.js
-        # see: https://github.com/nodejs/help/issues/554#issuecomment-290041018
-        subprocess.run("sudo apt-get install npm", shell=True, check=True)
+        subprocess.run(
+            f". $HOME/.nvm/nvm.sh && nvm install {NODE_JS_VERSION}",
+            shell=True,
+            check=True,
+            executable="/bin/bash",
+        )
 
 
 def setup_access_point():
@@ -153,14 +158,14 @@ def done():
 
 def execute_all():
     print_header()
-    check_super_user()
+    # check_super_user()
 
     install_node()
-    setup_access_point()
+    # setup_access_point()
 
-    install_server_dependencies()
-    build_server()
-    setup_server_service()
+    # install_server_dependencies()
+    # build_server()
+    # setup_server_service()
 
     done()
 


### PR DESCRIPTION
Closes #10.

Previously, we used the package manager `apt`, which led to issue #10. Instead, we now use the [recommended](https://nodejs.org/en/download) Node version manager [`nvm`](https://github.com/nvm-sh/nvm). We also install the `v22.x` version which is the current LTS version, see the [releases section](https://nodejs.org/en/about/previous-releases) of Node.js.